### PR TITLE
[workflow] Setup GitHub actions for CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,4 +11,4 @@ jobs:
         with:
           java-version: 1.8
       - name: Build with Gradle
-        run: cd Events/app/ && ./gradlew build
+        run: cd Events/app/ && gradle build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,14 @@
+name: CI
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Gradle
+        run: cd Events/app/ && ./gradlew build

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -10,5 +10,7 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Setup dummy Google Map API Key
+        run: echo "GOOGLE_MAPS_API_KEY=DUMMY" >> Events/gradle.properties
       - name: Build with Gradle
         run: cd Events/app/ && gradle build

--- a/Events/app/build.gradle
+++ b/Events/app/build.gradle
@@ -10,6 +10,7 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        resValue "string", "google_maps_key", (project.findProperty("GOOGLE_MAPS_API_KEY") ?: "")
     }
     buildTypes {
         release {

--- a/Events/app/src/release/res/values/google_maps_api.xml
+++ b/Events/app/src/release/res/values/google_maps_api.xml
@@ -16,5 +16,5 @@
     Once you have your key (it starts with "AIza"), replace the "google_maps_key"
     string in this file.
     -->
-	<string title="google_maps_key" templateMergeStrategy="preserve" translatable="false">YOUR_KEY_HERE</string>
+	<string name="google_maps_key" title="google_maps_key" templateMergeStrategy="preserve" translatable="false">YOUR_KEY_HERE</string>
 </resources>


### PR DESCRIPTION
# Description

This pull request setups up GitHub actions for cue android. It will build every commit in pull request.
Right now it writes to gradle.properties a dummy key for CI purposes. Eventually we want to setup this properly so everything can still be automated without leaking anything.

## Type of change

- [x] Automation

# How Has This Been Tested?

See directly on GitHub

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
