### PR TITLE
Set android.useAndroidX=true

### DIFF
--- a/Events/gradle.properties
+++ b/Events/gradle.properties
@@ -16,3 +16,4 @@ org.gradle.jvmargs=-Xmx1536m
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
 org.gradle.daemon=true
+android.useAndroidX=true


### PR DESCRIPTION
### Summary

We are using androidX here: https://github.com/cornell-dti/events-manager-android/blob/ca51891eed2e87a6957c2b71c213bc5887f7fbf9/Events/app/build.gradle#L31-L35

### Test Plan

Relevant Docs: https://developer.android.com/jetpack/androidx/migrate

It still compiles. See CI.